### PR TITLE
Fix tab highlighting/calendar navigation (#4)

### DIFF
--- a/chrome/content/day_tabs.js
+++ b/chrome/content/day_tabs.js
@@ -43,45 +43,43 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 	LightningCalendarTabs.dayTabs.prototype.show = function(tabs) {
 		LightningCalendarTabs.tabs.prototype.show.call(this);
 		
-		var date = new Date();
+		var date = LightningCalendarTabs.tabUtils.getCalendarToday();
 
-		for(var i = - this.pastDays; i <= this.futureDays; i++) {
+		if(date) {
+			for(var i = - this.pastDays; i <= this.futureDays; i++) {
+				var dateStart = date.clone();
+				dateStart.day+= i;
 
-			var dateStart = new Date(date);
-			dateStart.setDate(date.getDate() + i);
+				var tab = document.createElement("tab");
+				this.makeTabLabel(tab, dateStart);
 
-			var tab = document.createElement("tab");
-			this.makeTabLabel(tab, dateStart);
-			
-			LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, dateStart, this.periodType);
+				LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, dateStart, this.periodType);
 
-			tab.addEventListener("click", (function(self, date) {
-				return function() {
-					self.selectDay(date);
-				};
-			})(this, dateStart), false);
-			tabs.appendChild(tab);
+				tab.addEventListener("click", (function(self, date) {
+					return function() {
+						self.selectDay(date);
+					};
+				})(this, dateStart), false);
+				tabs.appendChild(tab);
 
-			this.tabs.push({
-				"tab" : tab,
-				"date" : dateStart
-			});
+				this.tabs.push({
+					"tab" : tab,
+					"date" : dateStart
+				});
+			}
 		}
 	};
 
 	LightningCalendarTabs.dayTabs.prototype.selectDay = function(date) {
-		currentView().goToDay(LightningCalendarTabs.tabUtils.jsDateToDateTime(date));
+		currentView().goToDay(date);
 	};
 
 	LightningCalendarTabs.dayTabs.prototype.dateEqual = function(a, b) {
-		if(a instanceof Date && b instanceof Date) {
-			return a.getDate() == b.getDate() && a.getMonth() == b.getMonth() && a.getFullYear() == b.getFullYear();
-		}
-		return false;
+		return a.day == b.day && a.month == b.month && a.year == b.year;
 	};
 	
 	LightningCalendarTabs.dayTabs.prototype.makeTabLabel = function(tab, date) {
-		tab.setAttribute("label", this.formatter.formatDate(LightningCalendarTabs.tabUtils.jsDateToDateTime(date)));
+		tab.setAttribute("label", this.formatter.formatDate(date));
 	};
 
 })();

--- a/chrome/content/month_tabs.js
+++ b/chrome/content/month_tabs.js
@@ -43,55 +43,43 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 	LightningCalendarTabs.monthTabs.prototype.show = function(tabs) {
 		LightningCalendarTabs.tabs.prototype.show.call(this);
 		
-		var date = new Date();
-		date.setDate(1);
+		var date = LightningCalendarTabs.tabUtils.getCalendarToday();
+		if(date) {
+			date = date.startOfMonth;
+			for(var i = - this.pastMonths; i <= this.futureMonths; i++) {
+				var tmpDate = date.clone();
+				tmpDate.month+= i;
 
-		var formatter = cal.getDateFormatter();
+				var tab = document.createElement("tab");
+				this.makeTabLabel(tab, tmpDate);
 
-		for(var i = - this.pastMonths; i <= this.futureMonths; i++) {
-			var tmpDate = new Date(date);
-			tmpDate.setMonth(tmpDate.getMonth() + i);
+				LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, tmpDate, this.periodType);
 
-			var tab = document.createElement("tab");
-			this.makeTabLabel(tab, tmpDate);
-			
-			LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, tmpDate, this.periodType);
+				tab.addEventListener("click", (function(self, date) {
+					return function() {
+						self.selectMonth(date);
+					};
+				})(this, tmpDate), false);
+				tabs.appendChild(tab);
 
-			tab.addEventListener("click", (function(self, date) {
-				return function() {
-					self.selectMonth(date);
-				};
-			})(this, tmpDate), false);
-			tabs.appendChild(tab);
-
-			this.tabs.push({
-				"tab" : tab,
-				"date" : tmpDate
-			});
-		}
-	};
-
-	LightningCalendarTabs.monthTabs.prototype.selectMonth = function(date) {
-		var dateStart = currentView().rangeStartDate;
-		if(dateStart) {
-			var dy = date.getFullYear() - dateStart.year;
-			var dm = date.getMonth() - dateStart.month;
-			var d = (dy * 12) + dm;
-			if(d != 0) {
-				currentView().moveView(d);
+				this.tabs.push({
+					"tab" : tab,
+					"date" : tmpDate
+				});
 			}
 		}
 	};
 
+	LightningCalendarTabs.monthTabs.prototype.selectMonth = function(date) {
+		currentView().goToDay(date);
+	};
+
 	LightningCalendarTabs.monthTabs.prototype.dateEqual = function(a, b) {
-		if(a instanceof Date && b instanceof Date) {
-			return a.getMonth() == b.getMonth() && a.getFullYear() == b.getFullYear();
-		}
-		return false;
+		return a.month == b.month && a.year == b.year;
 	};
 	
 	LightningCalendarTabs.monthTabs.prototype.makeTabLabel = function(tab, date) {
-		tab.setAttribute("label", this.formatter.monthName(date.getMonth()) + " " + date.getFullYear());
+		tab.setAttribute("label", this.formatter.monthName(date.month) + " " + date.year);
 	};
 
 })();

--- a/chrome/content/tabs.js
+++ b/chrome/content/tabs.js
@@ -258,9 +258,9 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 	};
 
 	LightningCalendarTabs.tabs.prototype.highlightCurrent = function(tabs) {
-		var dateStart = currentView().rangeStartDate;
+		var dateStart = LightningCalendarTabs.tabUtils.getCalendarStartDate();
 		if(dateStart) {
-			this.updateTabsState(tabs, new Date(Date.UTC(dateStart.year, dateStart.month, dateStart.day)));
+			this.updateTabsState(tabs, dateStart);
 		}
 	};
 
@@ -277,7 +277,7 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 
 	LightningCalendarTabs.tabs.prototype.updateOtherTab = function(tabs, date) {
 		if(this.otherDateTabEnabled && this.tabs.length > 0) {
-			if(date.getTime() < this.tabs[0].date) {
+			if(date.nativeTime < this.tabs[0].date.nativeTime) {
 				tabs.insertBefore(this.otherTab, tabs.firstChild);
 				tabs.selectedIndex = 0;
 			} else {

--- a/chrome/content/tabs_utils.js
+++ b/chrome/content/tabs_utils.js
@@ -60,33 +60,33 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 
 		//color for new period tab
 		var newPeriodColor = prefs.getCharPref("extensions.lightningcalendartabs.tabs.text_color_new_period");
-		var tmp = new Date(date);
+		var tmp = date.clone();
 		switch(periodType) {
 			case this.PERIOD_WEEK: {
 				//contains first day of month
-				tmp.setDate(date.getDate() + 7);
-				if(date.getMonth() != tmp.getMonth() || date.getDate() == 1) {
+				tmp.day+= 7;
+				if(date.month != tmp.month || date.day == 1) {
 					tab.style.color = newPeriodColor;
 				}
 			} break;
 			case this.PERIOD_MULTIWEEK: {
 				//contains new year
 				var weekCount = Preferences.get("calendar.weeks.inview", 4);
-				tmp.setDate(date.getDate() + ((weekCount - 1) * 7) + 6);
-				if(date.getFullYear() != tmp.getFullYear() || (date.getMonth() == 0 && date.getDate() == 1)) {
+				tmp.day+= ((weekCount - 1) * 7) + 6;
+				if(date.year != tmp.year || (date.month == 0 && date.day == 1)) {
 					tab.style.color = newPeriodColor;
 				}
 			} break;
 			case this.PERIOD_MONTH: {
 				//first month of year
-				if(date.getMonth() == 0) {
+				if(date.month == 0) {
 					tab.style.color = newPeriodColor;
 				}
 			} break;
 			case this.PERIOD_DAY: {
 				//first day of week
 				var weekStartDay = Preferences.get("calendar.week.start", 0);
-				if(date.getDay() == weekStartDay) {
+				if(date.weekday == weekStartDay) {
 					tab.style.color = newPeriodColor;
 				}
 			} break;
@@ -95,17 +95,18 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 		tab.setAttribute("class", classNames);
 	};
 
-	LightningCalendarTabs.tabUtils.jsDateToDateTime = function(aDate) {
-		var ret = cal.jsDateToDateTime(aDate);
-		return ret;
-	};
+	LightningCalendarTabs.tabUtils.getCalendarToday = function() {
+		return  currentView().today();
+	}
+
+	LightningCalendarTabs.tabUtils.getCalendarStartDate = function() {
+		return currentView().rangeStartDate;
+	}
 	
 	LightningCalendarTabs.tabUtils.resetDateToWeekStart = function(date) {
 		var weekStartDay = Preferences.get("calendar.week.start", 0);
-		var tmp = new Date(date);
-		while(tmp.getDay() != weekStartDay) {
-			tmp.setDate(tmp.getDate() - 1);
-		}
+		var tmp = date.clone();
+		tmp.day-= (tmp.weekday - weekStartDay + 7) % 7;
 		return tmp;
 	};
 

--- a/chrome/content/week_tabs.js
+++ b/chrome/content/week_tabs.js
@@ -45,61 +45,56 @@ var LightningCalendarTabs = LightningCalendarTabs || {};
 	LightningCalendarTabs.weekTabs.prototype.show = function(tabs) {
 		LightningCalendarTabs.tabs.prototype.show.call(this);
 		
-		var date = LightningCalendarTabs.tabUtils.resetDateToWeekStart(new Date());
+		var calendarToday = LightningCalendarTabs.tabUtils.getCalendarToday();
+		if (calendarToday) {
+			var date = LightningCalendarTabs.tabUtils.resetDateToWeekStart(calendarToday);
 
-		for(var i = - this.pastWeeks; i <= this.futureWeeks; i++) {
+			for(var i = - this.pastWeeks; i <= this.futureWeeks; i++) {
+				var dateStart = date.clone();
+				dateStart.day+= i * 7;
 
-			var dateStart = new Date(date);
-			dateStart.setDate(date.getDate() + (i * 7));
+				var tab = document.createElement("tab");
+				this.makeTabLabel(tab, dateStart);
 
-			var tab = document.createElement("tab");
-			this.makeTabLabel(tab, dateStart);
+				LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, dateStart, this.periodType);
 
-			LightningCalendarTabs.tabUtils.prepareTabVisual(tab, i, dateStart, this.periodType);
+				tab.addEventListener("click", (function(self, date) {
+					return function() {
+						self.selectWeek(date);
+					};
+				})(this, dateStart), false);
+				tabs.appendChild(tab);
 
-			tab.addEventListener("click", (function(self, date) {
-				return function() {
-					self.selectWeek(date);
-				};
-			})(this, dateStart), false);
-			tabs.appendChild(tab);
-
-			this.tabs.push({
-				"tab" : tab,
-				"date" : dateStart
-			});
+				this.tabs.push({
+					"tab" : tab,
+					"date" : dateStart
+				});
+			}
 		}
 	};
 
 	LightningCalendarTabs.weekTabs.prototype.highlightCurrent = function(tabs) {
-		var dateStart = currentView().rangeStartDate;
-		if(dateStart) {
-			var jsDateStart = LightningCalendarTabs.tabUtils.resetDateToWeekStart(new Date(Date.UTC(dateStart.year, dateStart.month, dateStart.day)));
+		var dateStart = LightningCalendarTabs.tabUtils.getCalendarStartDate();
+		if (dateStart) {
+			var jsDateStart = LightningCalendarTabs.tabUtils.resetDateToWeekStart(dateStart);
 			this.updateTabsState(tabs, jsDateStart);
 		}
 	};
 
 	LightningCalendarTabs.weekTabs.prototype.selectWeek = function(date) {
-		currentView().goToDay(LightningCalendarTabs.tabUtils.jsDateToDateTime(date));
+		currentView().goToDay(date);
 	};
 
 	LightningCalendarTabs.weekTabs.prototype.dateEqual = function(a, b) {
-		if(a instanceof Date && b instanceof Date) {
-			return a.getDate() == b.getDate() && a.getMonth() == b.getMonth() && a.getFullYear() == b.getFullYear();
-		}
-		return false;
+		return a.day == b.day && a.month == b.month && a.year == b.year;
 	};
 	
-	LightningCalendarTabs.weekTabs.prototype.makeTabLabel = function(tab, date) {
-		var dateEnd = new Date(date);
-		dateEnd.setDate(dateEnd.getDate() + 6);
-		var dateA = LightningCalendarTabs.tabUtils.jsDateToDateTime(date);
-		var dateB = LightningCalendarTabs.tabUtils.jsDateToDateTime(dateEnd);
-		dateA.isDate = true;
-		dateB.isDate = true;
-		var label = this.formatter.formatInterval(dateA, dateB);
-
-		tab.setAttribute("label", label);
+	LightningCalendarTabs.weekTabs.prototype.makeTabLabel = function(tab, dateStart) {
+		var dateEnd = dateStart.clone();
+		dateEnd.day+= 6;
+		dateStart.isDate = true;
+		dateEnd.isDate = true;
+		tab.setAttribute("label", this.formatter.formatInterval(dateStart, dateEnd));
 	};
 
 })();


### PR DESCRIPTION
This PR closes the bug described in #4.
The bug occurred because of inproper handling of UTC/timezones in this extension. It is using JavaScript's builtin `Date` objects (which use the computer's timezone) as opposed to Mozilla's `DateTime` objects. Internally, the Lightning Calendar uses a timezone that might differ from the computer's timezone (user configurable in the Lightning Calendar settings), which can lead to an over/underflow of the date when it is converted from `Date` to `DateTime`.

Fixing this bug using JavaScript `Date` objects seemed very (!) confusing, thus I opted for replacing its usage in this extension with `DateTime` objects. This makes any conversions from or to Date objects obsolete, as required several times in this extension.

This PR also prevents unintended behaviour when the user changes the calendar's timezone (or start of the week) while Thunderbird is running.